### PR TITLE
Fix Firebase POI test credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
         working-directory: geo-poi-database
         env:
           GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}

--- a/geo-poi-database/README.md
+++ b/geo-poi-database/README.md
@@ -1,0 +1,36 @@
+# Geo POI Firebase Tests
+
+The geo POI integration test reads from the real Firestore `pois` collection. It does not seed data during the test, so the Firebase project must already contain the expected POI documents.
+
+## Local Setup
+
+Set the Firebase project ID:
+
+```powershell
+$env:GCLOUD_PROJECT = "your-real-firebase-project-id"
+```
+
+Then provide service account credentials using one of these options.
+
+For local development, point `GOOGLE_APPLICATION_CREDENTIALS` at a downloaded service account JSON file:
+
+```powershell
+$env:GOOGLE_APPLICATION_CREDENTIALS = "C:\absolute\path\to\service-account.json"
+npm test
+```
+
+For CI or environments where creating a file is inconvenient, provide the full service account JSON in `FIREBASE_SERVICE_ACCOUNT_JSON`:
+
+```powershell
+$env:FIREBASE_SERVICE_ACCOUNT_JSON = Get-Content "C:\absolute\path\to\service-account.json" -Raw
+npm test
+```
+
+## GitHub Actions Secrets
+
+Configure these repository secrets:
+
+- `GCLOUD_PROJECT`: the Firebase project ID.
+- `FIREBASE_SERVICE_ACCOUNT_JSON`: the full contents of the service account JSON file.
+
+The service account needs permission to read the Firestore `pois` collection. The test currently expects the `bay-area-jimmy-hendrix-house` document to exist with a `culture` tag and `geo.geopoint` / `geo.geohash` fields.

--- a/geo-poi-database/firebase_admin.js
+++ b/geo-poi-database/firebase_admin.js
@@ -1,0 +1,81 @@
+const admin = require("firebase-admin");
+
+const PLACEHOLDER_PROJECT_ID = "your-firebase-project-id";
+const PLACEHOLDER_CREDENTIALS_PATH = "C:\\path\\to";
+
+function hasCloudProjectId() {
+  return (
+    Boolean(process.env.GCLOUD_PROJECT) &&
+    process.env.GCLOUD_PROJECT !== PLACEHOLDER_PROJECT_ID
+  );
+}
+
+function hasCredentialsFilePath() {
+  return (
+    Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS) &&
+    !process.env.GOOGLE_APPLICATION_CREDENTIALS.includes(PLACEHOLDER_CREDENTIALS_PATH)
+  );
+}
+
+function parseServiceAccountJson() {
+  if (!process.env.FIREBASE_SERVICE_ACCOUNT_JSON) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_JSON);
+  } catch (error) {
+    throw new Error(
+      `FIREBASE_SERVICE_ACCOUNT_JSON must be valid service account JSON: ${error.message}`,
+    );
+  }
+}
+
+function getMissingFirebaseConfigMessage() {
+  return [
+    "Firestore cloud access is not configured.",
+    "Set GCLOUD_PROJECT to the Firebase project ID.",
+    "Then provide credentials with either:",
+    "- GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service-account.json",
+    "- FIREBASE_SERVICE_ACCOUNT_JSON='{\"type\":\"service_account\",...}'",
+  ].join("\n");
+}
+
+function getFirebaseAdminApp() {
+  if (admin.apps.length > 0) {
+    return admin.app();
+  }
+
+  if (!hasCloudProjectId()) {
+    throw new Error(getMissingFirebaseConfigMessage());
+  }
+
+  const serviceAccount = parseServiceAccountJson();
+
+  if (serviceAccount) {
+    return admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount),
+      projectId: process.env.GCLOUD_PROJECT,
+    });
+  }
+
+  if (hasCredentialsFilePath()) {
+    return admin.initializeApp({
+      credential: admin.credential.applicationDefault(),
+      projectId: process.env.GCLOUD_PROJECT,
+    });
+  }
+
+  throw new Error(getMissingFirebaseConfigMessage());
+}
+
+function getFirestore() {
+  delete process.env.FIRESTORE_EMULATOR_HOST;
+  return admin.firestore(getFirebaseAdminApp());
+}
+
+module.exports = {
+  getFirebaseAdminApp,
+  getFirestore,
+  getMissingFirebaseConfigMessage,
+};

--- a/geo-poi-database/seed_pois.js
+++ b/geo-poi-database/seed_pois.js
@@ -2,6 +2,7 @@ const fs = require("node:fs/promises");
 const path = require("node:path");
 const admin = require("firebase-admin");
 const geofire = require("geofire-common");
+const { getFirestore: getCloudFirestore } = require("./firebase_admin");
 
 function configureEnvironment({ useCloud = false } = {}) {
   if (useCloud) {
@@ -33,6 +34,10 @@ function configureEnvironment({ useCloud = false } = {}) {
 }
 
 function getFirestore() {
+  if (!process.env.FIRESTORE_EMULATOR_HOST) {
+    return getCloudFirestore();
+  }
+
   if (!admin.apps.length) {
     admin.initializeApp({
       projectId: process.env.GCLOUD_PROJECT,

--- a/tests/geo_poi_database.test.js
+++ b/tests/geo_poi_database.test.js
@@ -8,20 +8,7 @@ const geoPoiRequire = createRequire(
 );
 const admin = geoPoiRequire("firebase-admin");
 const geofire = geoPoiRequire("geofire-common");
-
-delete process.env.FIRESTORE_EMULATOR_HOST;
-
-const app =
-  process.env.GCLOUD_PROJECT &&
-  process.env.GCLOUD_PROJECT !== "your-firebase-project-id" &&
-  process.env.GOOGLE_APPLICATION_CREDENTIALS &&
-  !process.env.GOOGLE_APPLICATION_CREDENTIALS.includes("C:\\path\\to")
-    ? admin.initializeApp({
-        projectId: process.env.GCLOUD_PROJECT,
-      })
-    : null;
-
-const db = app ? admin.firestore(app) : null;
+const { getFirestore } = geoPoiRequire("./firebase_admin.js");
 
 function distanceInMiles(origin, destination) {
   const earthRadiusMiles = 3958.8;
@@ -47,9 +34,7 @@ function distanceInMiles(origin, destination) {
 }
 
 async function queryPois({ location, radiusMiles, preferences }) {
-  if (!db) {
-    throw new Error("Firestore is not configured for this test run.");
-  }
+  const db = getFirestore();
 
   const center = [location.latitude, location.longitude];
   const radiusMeters = radiusMiles * 1609.344;
@@ -113,24 +98,23 @@ async function queryPois({ location, radiusMiles, preferences }) {
 
 test(
   "geo POI database returns expected POIs for a valid location query",
-  {
-    skip: "Deferred to Sprint 2: requires dedicated Firebase credentials and seeded cloud test data in CI.",
-  },
   async () => {
-  const jimmyHendrixHouseLocation = {
-    latitude: 37.770058,
-    longitude: -122.447466,
-  };
+    const jimmyHendrixHouseLocation = {
+      latitude: 37.770058,
+      longitude: -122.447466,
+    };
 
-  const results = await queryPois({
-    location: jimmyHendrixHouseLocation,
-    radiusMiles: 1.2,
-    preferences: ["culture"],
-  });
+    const results = await queryPois({
+      location: jimmyHendrixHouseLocation,
+      radiusMiles: 1.2,
+      preferences: ["culture"],
+    });
 
-  assert.ok(
-    results.some((poi) => poi.id === "bay-area-jimmy-hendrix-house"),
-    "Expected Bay Area Jimmy Hendrix House to be included in culture POI results",
-  );
+    assert.ok(
+      results.some((poi) => poi.id === "bay-area-jimmy-hendrix-house"),
+      "Expected Bay Area Jimmy Hendrix House to be included in culture POI results",
+    );
+
+    await Promise.all(admin.apps.map((app) => app.delete()));
   },
 );


### PR DESCRIPTION
Support service account JSON secrets for CI and document the real Firestore setup so the POI integration test can run without local credential paths.